### PR TITLE
Rfe#26wip

### DIFF
--- a/.github/workflows/frodo.yml
+++ b/.github/workflows/frodo.yml
@@ -90,6 +90,7 @@ jobs:
           appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
           appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
           primary-bundle-id: "frodo"
+          verbose: "true"
 
       - name: "Staple Release Build"
         uses: devbotsxyz/xcode-staple@v1

--- a/.github/workflows/frodo.yml
+++ b/.github/workflows/frodo.yml
@@ -31,12 +31,12 @@ jobs:
           certificate-passphrase: ${{ secrets.DEVELOPMENT_CERTIFICATE_PASSPHRASE }}
           keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
 
-      - name: "Import Certificate: Distribution"
-        uses: devbotsxyz/import-signing-certificate@v1
-        with:
-          certificate-data: ${{ secrets.DISTRIBUTION_CERTIFICATE_DATA }}
-          certificate-passphrase: ${{ secrets.DISTRIBUTION_CERTIFICATE_PASSPHRASE }}
-          keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
+      # - name: "Import Certificate: Distribution"
+      #   uses: devbotsxyz/import-signing-certificate@v1
+      #   with:
+      #     certificate-data: ${{ secrets.DISTRIBUTION_CERTIFICATE_DATA }}
+      #     certificate-passphrase: ${{ secrets.DISTRIBUTION_CERTIFICATE_PASSPHRASE }}
+      #     keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
 
       - name: Install pkg
         run: npm install -g pkg
@@ -76,26 +76,26 @@ jobs:
       #
       - name: Sign distribution binary
         working-directory: ./dist/bin/macos
-        run: "codesign -f -s 'Apple Distribution: Volker Scheuber (AV6L99G8W9)' --timestamp --deep frodo"
+        run: "codesign -f -s 'Developer ID Application: Volker Scheuber (AV6L99G8W9)' --timestamp --deep frodo"
 
       #
       # Now send the product to Apple's notarization service and then
       # staple it.
       #
 
-      - name: "Notarize Release Build"
-        uses: devbotsxyz/xcode-notarize@v1
-        with:
-          product-path: "dist/bin/macos/frodo"
-          appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
-          appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
-          primary-bundle-id: "frodo"
-          verbose: "true"
+      # - name: "Notarize Release Build"
+      #   uses: devbotsxyz/xcode-notarize@v1
+      #   with:
+      #     product-path: "dist/bin/macos/frodo"
+      #     appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
+      #     appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+      #     primary-bundle-id: "frodo"
+      #     verbose: "true"
 
-      - name: "Staple Release Build"
-        uses: devbotsxyz/xcode-staple@v1
-        with:
-          product-path: "dist/bin/macos/frodo"
+      # - name: "Staple Release Build"
+      #   uses: devbotsxyz/xcode-staple@v1
+      #   with:
+      #     product-path: "dist/bin/macos/frodo"
 
       #
       # Zip up the app and add it to the GitHub Release as a

--- a/.github/workflows/frodo.yml
+++ b/.github/workflows/frodo.yml
@@ -76,7 +76,7 @@ jobs:
       #
       - name: Sign distribution binary
         working-directory: ./dist/bin/macos
-        run: codesign -f -s "Apple Distribution: Volker Scheuber (AV6L99G8W9)" frodo --deep
+        run: codesign -f -s 'Apple Distribution: Volker Scheuber (AV6L99G8W9)' frodo --deep
 
       #
       # Now send the product to Apple's notarization service and then

--- a/.github/workflows/frodo.yml
+++ b/.github/workflows/frodo.yml
@@ -24,12 +24,12 @@ jobs:
         with:
           version: "13"
 
-      - name: "Import Certificate: Development"
-        uses: devbotsxyz/import-signing-certificate@v1
-        with:
-          certificate-data: ${{ secrets.DEVELOPMENT_CERTIFICATE_DATA }}
-          certificate-passphrase: ${{ secrets.DEVELOPMENT_CERTIFICATE_PASSPHRASE }}
-          keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
+      # - name: "Import Certificate: Development"
+      #   uses: devbotsxyz/import-signing-certificate@v1
+      #   with:
+      #     certificate-data: ${{ secrets.DEVELOPMENT_CERTIFICATE_DATA }}
+      #     certificate-passphrase: ${{ secrets.DEVELOPMENT_CERTIFICATE_PASSPHRASE }}
+      #     keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
 
       # - name: "Import Certificate: Distribution"
       #   uses: devbotsxyz/import-signing-certificate@v1
@@ -37,6 +37,28 @@ jobs:
       #     certificate-data: ${{ secrets.DISTRIBUTION_CERTIFICATE_DATA }}
       #     certificate-passphrase: ${{ secrets.DISTRIBUTION_CERTIFICATE_PASSPHRASE }}
       #     keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
+
+    - name: Install the Apple certificate
+      env:
+        DEVELOPMENT_CERTIFICATE_DATA: ${{ secrets.DEVELOPMENT_CERTIFICATE_DATA }}
+        DEVELOPMENT_CERTIFICATE_PASSPHRASE: ${{ secrets.DEVELOPMENT_CERTIFICATE_PASSPHRASE }}
+        KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+      run: |
+        # create variables
+        CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+        KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+        # import certificate from secrets
+        echo -n "$DEVELOPMENT_CERTIFICATE_DATA" | base64 --decode --output $CERTIFICATE_PATH
+
+        # create temporary keychain
+        security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+        security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+        # import certificate to keychain
+        security import $CERTIFICATE_PATH -P "$DEVELOPMENT_CERTIFICATE_PASSPHRASE" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+        security list-keychain -d user -s $KEYCHAIN_PATH
 
       - name: Install pkg
         run: npm install -g pkg

--- a/.github/workflows/frodo.yml
+++ b/.github/workflows/frodo.yml
@@ -38,7 +38,7 @@ jobs:
 
           # import certificate to keychain
           security import $CERTIFICATE_PATH -P "$DEVELOPMENT_CERTIFICATE_PASSPHRASE" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security import $CERTIFICATE_PATH -P "$DEVELOPMENT_CERTIFICATE_PASSPHRASE" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          #security import $INTERMEDIATE_CERTIFICATE_PATH -P "$DEVELOPMENT_CERTIFICATE_PASSPHRASE" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
 
       - name: Install pkg
@@ -171,7 +171,7 @@ jobs:
         run: pkg -C Gzip -t node16-win-x64 --out-path bin/win .
 
       - name: Archive distribution binary
-        run: zip -r -Z bzip2 dist/frodo-win.zip . -i dist/bin/win/frodo.exe
+        run: zip -r dist/frodo-win.zip . -i dist/bin/win/frodo.exe
 
       - name: Release distribution binaries
         uses: softprops/action-gh-release@v0.1.14

--- a/.github/workflows/frodo.yml
+++ b/.github/workflows/frodo.yml
@@ -19,14 +19,17 @@ jobs:
         env:
           DEVELOPMENT_CERTIFICATE_DATA: ${{ secrets.DEVELOPMENT_CERTIFICATE_DATA }}
           DEVELOPMENT_CERTIFICATE_PASSPHRASE: ${{ secrets.DEVELOPMENT_CERTIFICATE_PASSPHRASE }}
+          INTERMEDIATE_CERTIFICATE_DATA: ${{ secrets.INTERMEDIATE_CERTIFICATE_DATA }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
           # create variables
           CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          INTERMEDIATE_CERTIFICATE_PATH=$RUNNER_TEMP/intermediate_certificate.p12
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
-          # import certificate from secrets
+          # import certificates from secrets
           echo -n "$DEVELOPMENT_CERTIFICATE_DATA" | base64 --decode --output $CERTIFICATE_PATH
+          echo -n "$INTERMEDIATE_CERTIFICATE_DATA" | base64 --decode --output $INTERMEDIATE_CERTIFICATE_PATH
 
           # create temporary keychain
           security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
@@ -34,6 +37,7 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 
           # import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$DEVELOPMENT_CERTIFICATE_PASSPHRASE" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           security import $CERTIFICATE_PATH -P "$DEVELOPMENT_CERTIFICATE_PASSPHRASE" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
 
@@ -75,7 +79,8 @@ jobs:
       #
       - name: Sign distribution binary
         working-directory: ./dist/bin/macos
-        run: "codesign -f -s 'Developer ID Application: Volker Scheuber (AV6L99G8W9)' --timestamp --deep frodo"
+        run: "codesign -f -s 'Rock Carver' --timestamp --deep frodo"
+        # run: "codesign -f -s 'Developer ID Application: Volker Scheuber (AV6L99G8W9)' --timestamp --deep frodo"
 
       #
       # Zip up the app and add it to the GitHub Release as a

--- a/.github/workflows/frodo.yml
+++ b/.github/workflows/frodo.yml
@@ -89,6 +89,7 @@ jobs:
           product-path: "dist/bin/macos/frodo"
           appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
           appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+          primary-bundle-id: "frodo"
 
       - name: "Staple Release Build"
         uses: devbotsxyz/xcode-staple@v1

--- a/.github/workflows/frodo.yml
+++ b/.github/workflows/frodo.yml
@@ -76,7 +76,7 @@ jobs:
       #
       - name: Sign distribution binary
         working-directory: ./dist/bin/macos
-        run: codesign -f -s 'Apple Distribution: Volker Scheuber (AV6L99G8W9)' frodo --deep
+        run: "codesign -f -s 'Apple Distribution: Volker Scheuber (AV6L99G8W9)' frodo --deep"
 
       #
       # Now send the product to Apple's notarization service and then

--- a/.github/workflows/frodo.yml
+++ b/.github/workflows/frodo.yml
@@ -5,7 +5,7 @@ name: Binary release (linux, macos, win)
 
 on:
   release:
-    types: [ created ]
+    types: [ created, edited ]
 
 jobs:
   macos-release:

--- a/.github/workflows/frodo.yml
+++ b/.github/workflows/frodo.yml
@@ -5,7 +5,7 @@ name: Binary release (linux, macos, win)
 
 on:
   release:
-    types: [ created, edited ]
+    types: [ created ]
 
 jobs:
   macos-release:
@@ -15,50 +15,27 @@ jobs:
       - name: "Checkout Project"
         uses: actions/checkout@v2
 
-      #
-      # Setup
-      #
+      - name: Install the Apple certificate
+        env:
+          DEVELOPMENT_CERTIFICATE_DATA: ${{ secrets.DEVELOPMENT_CERTIFICATE_DATA }}
+          DEVELOPMENT_CERTIFICATE_PASSPHRASE: ${{ secrets.DEVELOPMENT_CERTIFICATE_PASSPHRASE }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          # create variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
-      - name: "Select Xcode 13"
-        uses: devbotsxyz/xcode-select@v1
-        with:
-          version: "13"
+          # import certificate from secrets
+          echo -n "$DEVELOPMENT_CERTIFICATE_DATA" | base64 --decode --output $CERTIFICATE_PATH
 
-      # - name: "Import Certificate: Development"
-      #   uses: devbotsxyz/import-signing-certificate@v1
-      #   with:
-      #     certificate-data: ${{ secrets.DEVELOPMENT_CERTIFICATE_DATA }}
-      #     certificate-passphrase: ${{ secrets.DEVELOPMENT_CERTIFICATE_PASSPHRASE }}
-      #     keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
+          # create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 
-      # - name: "Import Certificate: Distribution"
-      #   uses: devbotsxyz/import-signing-certificate@v1
-      #   with:
-      #     certificate-data: ${{ secrets.DISTRIBUTION_CERTIFICATE_DATA }}
-      #     certificate-passphrase: ${{ secrets.DISTRIBUTION_CERTIFICATE_PASSPHRASE }}
-      #     keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
-
-    - name: Install the Apple certificate
-      env:
-        DEVELOPMENT_CERTIFICATE_DATA: ${{ secrets.DEVELOPMENT_CERTIFICATE_DATA }}
-        DEVELOPMENT_CERTIFICATE_PASSPHRASE: ${{ secrets.DEVELOPMENT_CERTIFICATE_PASSPHRASE }}
-        KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-      run: |
-        # create variables
-        CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-        KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-
-        # import certificate from secrets
-        echo -n "$DEVELOPMENT_CERTIFICATE_DATA" | base64 --decode --output $CERTIFICATE_PATH
-
-        # create temporary keychain
-        security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-        security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-        security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-
-        # import certificate to keychain
-        security import $CERTIFICATE_PATH -P "$DEVELOPMENT_CERTIFICATE_PASSPHRASE" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-        security list-keychain -d user -s $KEYCHAIN_PATH
+          # import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$DEVELOPMENT_CERTIFICATE_PASSPHRASE" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
 
       - name: Install pkg
         run: npm install -g pkg
@@ -99,25 +76,6 @@ jobs:
       - name: Sign distribution binary
         working-directory: ./dist/bin/macos
         run: "codesign -f -s 'Developer ID Application: Volker Scheuber (AV6L99G8W9)' --timestamp --deep frodo"
-
-      #
-      # Now send the product to Apple's notarization service and then
-      # staple it.
-      #
-
-      # - name: "Notarize Release Build"
-      #   uses: devbotsxyz/xcode-notarize@v1
-      #   with:
-      #     product-path: "dist/bin/macos/frodo"
-      #     appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
-      #     appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
-      #     primary-bundle-id: "frodo"
-      #     verbose: "true"
-
-      # - name: "Staple Release Build"
-      #   uses: devbotsxyz/xcode-staple@v1
-      #   with:
-      #     product-path: "dist/bin/macos/frodo"
 
       #
       # Zip up the app and add it to the GitHub Release as a

--- a/.github/workflows/frodo.yml
+++ b/.github/workflows/frodo.yml
@@ -76,7 +76,7 @@ jobs:
       #
       - name: Sign distribution binary
         working-directory: ./dist/bin/macos
-        run: "codesign -f -s 'Apple Distribution: Volker Scheuber (AV6L99G8W9)' frodo --deep"
+        run: "codesign -f -s 'Apple Distribution: Volker Scheuber (AV6L99G8W9)' --timestamp --deep frodo"
 
       #
       # Now send the product to Apple's notarization service and then

--- a/.github/workflows/frodo.yml
+++ b/.github/workflows/frodo.yml
@@ -184,7 +184,7 @@ jobs:
         run: pkg -C Gzip -t node16-win-x64 --out-path bin/win .
 
       - name: Archive distribution binary
-        run: zip -r -Z bzip2 dist/frodo-win.zip . -i dist/bin/win/frodo
+        run: zip -r -Z bzip2 dist/frodo-win.zip . -i dist/bin/win/frodo.exe
 
       - name: Release distribution binaries
         uses: softprops/action-gh-release@v0.1.14

--- a/.github/workflows/frodo.yml
+++ b/.github/workflows/frodo.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Build distribution binary
         working-directory: ./dist
-        run: pkg -C Gzip -t node16-macos-x64 --out-path bin/macos -o frodo .
+        run: pkg -C Gzip -t node16-macos-x64 --out-path bin/macos .
       #
       # Fail early on failing tests.
       # Disabled because this project does not have tests. (TODO Add some example tests)
@@ -139,7 +139,7 @@ jobs:
 
       - name: Build distribution binary
         working-directory: ./dist
-        run: pkg -C Gzip -t node16-linux-x64 --out-path bin/linux -o frodo .
+        run: pkg -C Gzip -t node16-linux-x64 --out-path bin/linux .
 
       - name: Archive distribution binary
         run: zip -r -Z bzip2 dist/frodo-linux.zip . -i dist/bin/linux/frodo
@@ -181,7 +181,7 @@ jobs:
 
       - name: Build distribution binary
         working-directory: ./dist
-        run: pkg -C Gzip -t node16-win-x64 --out-path bin/win -o frodo .
+        run: pkg -C Gzip -t node16-win-x64 --out-path bin/win .
 
       - name: Archive distribution binary
         run: zip -r -Z bzip2 dist/frodo-win.zip . -i dist/bin/win/frodo


### PR DESCRIPTION
Change binary releases to archived zip files. This allows the release of "frodo" binaries for all platforms, vs the frodo-linux, frodo-macos, and frodo-win we had previously.