### PR TITLE
Auto provisioning of log API keys

### DIFF
--- a/src/api/AuthApi.js
+++ b/src/api/AuthApi.js
@@ -18,7 +18,7 @@ const authorizeURLTemplate = "%s/oauth2%s/authorize"
 const accessTokenURLTemplate = "%s/oauth2%s/access_token"
 const redirectURLTemplate = "/platform/appAuthHelperRedirect.html"
 
-const idmAdminScope = "fr:idm:*"
+const idmAdminScope = "fr:idm:* openid"
 const authenticationApiVersion = "resource=2.0, protocol=1.0"
 const getAuthenticationApiConfig = () => {
     return {

--- a/src/api/BaseApi.js
+++ b/src/api/BaseApi.js
@@ -112,6 +112,36 @@ export function generateIdmApi(requestOverride = {}) {
 }
 
 /**
+ * Generates a LogKeys API Axios instance
+ * @param {object} requestOverride Takes an object of AXIOS parameters that can be used to either add
+ * on extra information or override default properties https://github.com/axios/axios#request-config
+ *
+ * @returns {AxiosInstance}
+ */
+ export function generateLogKeysApi(requestOverride = {}) {
+    const headers = {
+      'Content-type': 'application/json'
+    };
+    const requestDetails = {
+      baseURL: getTenantURL(storage.session.getTenant()),
+      timeout,
+      headers: headers,
+      ...requestOverride,
+      httpsAgent: new https.Agent({
+        rejectUnauthorized: !storage.session.getAllowInsecureConnection(),
+      }),
+    };
+
+    if (storage.session.getBearerToken()) {
+        requestDetails.headers.Authorization = `Bearer ${storage.session.getBearerToken()}`;
+    }
+    
+    const request = axios.create(requestDetails);
+ 
+    return request;
+  }
+  
+/**
  * Generates a Log API Axios instance
  * @param {object} requestOverride Takes an object of AXIOS parameters that can be used to either add
  * on extra information or override default properties https://github.com/axios/axios#request-config

--- a/src/api/LogApi.js
+++ b/src/api/LogApi.js
@@ -1,5 +1,6 @@
-import { generateLogApi } from './BaseApi.js';
+import { generateLogApi, generateLogKeysApi } from './BaseApi.js';
 import { getTenantURL } from './utils/ApiUtils.js';
+import { getCurrentTimestamp } from './utils/ExportImportUtils.js';
 import { saveConnection } from './AuthApi.js';
 import storage from '../storage/SessionStorage.js';
 import util from 'util';
@@ -131,6 +132,8 @@ const noise = misc_noise.concat(saml_noise).concat(journeys_noise)
 
 const logsTailURLTemplate = "%s/monitoring/logs/tail?source=%s";
 const logsSourcesURLTemplate = "%s/monitoring/logs/sources";
+const logsCreateAPIKeyAndSecretURLTemplate = "%s/keys?_action=create"
+const logsGetAPIKeysURLTemplate = "%s/keys"
 
 async function tail(source, cookie) {
     try {
@@ -152,6 +155,52 @@ async function tail(source, cookie) {
         return logsObject;
     } catch (e) {
         printMessage(`tail ERROR: tail data error - ${e}`, 'error');
+        return null;
+    }
+}
+
+async function getAPIKeys() {
+    try {
+        let urlString = util.format(logsGetAPIKeysURLTemplate, getTenantURL(storage.session.getTenant()));
+        const req = generateLogKeysApi();
+        const response = await req.get(urlString);
+        if (response.status < 200 || response.status > 399) {
+            printMessage(`get keys ERROR: get keys call returned ${response.status}`, 'error');
+            return null;
+        }
+        let logsKeyObject = response.data;
+        return logsKeyObject;
+    } catch (e) {
+        printMessage(`get keys ERROR: keys data error - ${e}`, 'error');
+        return null;
+    }
+}
+
+export async function createAPIKeyAndSecret() {
+    try {
+        let keyName = `frodo-${storage.session.getUsername()}`;
+        let existingKeys = await getAPIKeys();
+        existingKeys.result.forEach(k=>{
+          if(k.name == keyName) {
+            // append current timestamp to name if the named key already exists
+            keyName = `${keyName}-${getCurrentTimestamp()}`;
+          }
+        })
+        let urlString = util.format(logsCreateAPIKeyAndSecretURLTemplate, getTenantURL(storage.session.getTenant()));
+        const req = generateLogKeysApi();
+        const response = await req.post(urlString, {name: keyName});
+        if (response.status < 200 || response.status > 399) {
+            printMessage(`create keys ERROR: create keys call returned ${response.status}`, 'error');
+            return null;
+        }
+        let logsKeyObject = response.data;
+        if(logsKeyObject.name != keyName) {
+            printMessage(`create keys ERROR: could not create log API key ${keyName}`, 'error');
+            return null;    
+        }
+        return logsKeyObject;
+    } catch (e) {
+        printMessage(`create keys ERROR: create keys data error - ${e}`, 'error');
         return null;
     }
 }

--- a/src/api/LogApi.js
+++ b/src/api/LogApi.js
@@ -198,6 +198,7 @@ export async function createAPIKeyAndSecret() {
             printMessage(`create keys ERROR: could not create log API key ${keyName}`, 'error');
             return null;    
         }
+        printMessage(`Created a new log API key [${keyName}] in ${storage.session.getTenant()}`);
         return logsKeyObject;
     } catch (e) {
         printMessage(`create keys ERROR: create keys data error - ${e}`, 'error');

--- a/src/api/utils/ExportImportUtils.js
+++ b/src/api/utils/ExportImportUtils.js
@@ -62,6 +62,7 @@ function saveToFile(type, data, identifier, filename) {
 }
 
 export {
+  getCurrentTimestamp,
   saveToFile,
   convertBase64ScriptToArray,
   convertArrayToBase64Script,


### PR DESCRIPTION
log API keys are automatically created by frodo. They are named as below:
```
frodo-<username>[-ISO8660 timestamp]
```
For example, in most cases:
```
frodo-first.last@company.com
```
when there are naming conflicts, it will append a timestamp at the end to reduce any confusion:
```
frodo-first.last@company.com-2022-04-29T21:33:00.662Z
```
