### PR TITLE
Additional null check in tailLogs

### DIFF
--- a/src/api/LogApi.js
+++ b/src/api/LogApi.js
@@ -208,7 +208,7 @@ export async function createAPIKeyAndSecret() {
 
 export async function tailLogs(source, cookie) {
     const result = await tail(source, cookie);
-    if (result.result) {
+    if (result && result.result) {
         if (!cookie) {
             await saveConnection();
         }


### PR DESCRIPTION
Handled additional use-case where the complete response (log result) from ForgeRock Identity Cloud Log API is null.