### PR TITLE
Admin ui compatibilty: support export/import of JSON stringified scripts

### DIFF
--- a/src/api/BaseApi.js
+++ b/src/api/BaseApi.js
@@ -10,7 +10,7 @@ axiosRetry(axios, {
   // retryCondition: (_error) => true // retry no matter what
 });
 
-export const timeout = 20000;
+export const timeout = 30000;
 export const amApiVersion = 'resource=1.0';
 
 /**

--- a/src/api/utils/Base64.js
+++ b/src/api/utils/Base64.js
@@ -1,4 +1,19 @@
 /**
+ * Regex to determine if a string is Base64-encoded
+ */
+const base64regex =
+  /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
+
+/**
+ * Is input Base64-encoded
+ * @param {String} input
+ * @returns {boolean} true if input is Base64-encoded, false otherwise
+ */
+export function isBase64Encoded(input) {
+  return base64regex.test(input);
+}
+
+/**
  * Base64-encode a string
  * @param {String} input String to base64-encode
  * @returns {String} Base64-encoded input string

--- a/src/cli/journey/journey-export.js
+++ b/src/cli/journey/journey-export.js
@@ -45,6 +45,12 @@ program
       'Export all the journeys/trees in a realm as separate files <journey/tree name>.json. Ignored with -t or -a.'
     )
   )
+  .addOption(
+    new Option(
+      '--use-string-arrays',
+      'Where applicable, use string arrays to store multi-line text (e.g. scripts).'
+    ).default(false, 'off')
+  )
   .action(
     // implement command logic inside action handler
     async (host, realm, user, password, options) => {
@@ -58,17 +64,23 @@ program
         // export
         if (options.tree) {
           printMessage('Exporting journey...');
-          exportJourneyToFile(options.tree, options.file);
+          exportJourneyToFile(options.tree, options.file, {
+            useStringArrays: options.useStringArrays,
+          });
         }
         // --all -a
         else if (options.all) {
           printMessage('Exporting all journeys to a single file...');
-          exportJourneysToFile(options.file);
+          exportJourneysToFile(options.file, {
+            useStringArrays: options.useStringArrays,
+          });
         }
         // --all-separate -A
         else if (options.allSeparate) {
           printMessage('Exporting all journeys to separate files...');
-          exportJourneysToFiles();
+          exportJourneysToFiles({
+            useStringArrays: options.useStringArrays,
+          });
         }
         // unrecognized combination of options or no options
         else {

--- a/src/cli/journey/journey-import.js
+++ b/src/cli/journey/journey-import.js
@@ -48,8 +48,14 @@ program
   .addOption(
     new Option(
       '-n, --no-re-uuid',
-      'No Re-UUID. Frodo does not generate new UUIDs for any nodes during import. This results in updating (overwriting) existing trees/nodes instead of safely cloning them.'
-    )
+      "No Re-UUID. Frodo won't generate new UUIDs for any nodes during import. Updates (overwrites) existing trees/nodes instead of clone."
+    ).default(false, 'off')
+  )
+  .addOption(
+    new Option(
+      '-v, --verbose',
+      'Verbose output during command execution. If specified, may or may not produce additional output.'
+    ).default(false, 'off')
   )
   .action(
     // implement command logic inside action handler
@@ -64,21 +70,30 @@ program
         // import
         if (options.tree) {
           printMessage('Importing journey...');
-          importJourneyFromFile(options.tree, options.file, options.noReUuid);
+          importJourneyFromFile(options.tree, options.file, {
+            noReUuid: options.noReUuid,
+            verbose: options.verbose,
+          });
         }
         // --all -a
         else if (options.all && options.file) {
           printMessage(
             `Importing all journeys from a single file (${options.file})...`
           );
-          importJourneysFromFile(options.file, options.noReUuid);
+          importJourneysFromFile(options.file, {
+            noReUuid: options.noReUuid,
+            verbose: options.verbose,
+          });
         }
         // --all-separate -A
         else if (options.allSeparate && !options.file) {
           printMessage(
             'Importing all journeys from separate files in current directory...'
           );
-          importJourneysFromFiles(options.noReUuid);
+          importJourneysFromFiles({
+            noReUuid: options.noReUuid,
+            verbose: options.verbose,
+          });
         }
         // unrecognized combination of options or no options
         else {


### PR DESCRIPTION
Resolves #184 

Allow override on export using --use-string-arrays param. Import detects the encoding and handles it accordingly. Frodo supports the following encoding formats of scripts: Base64, JSON, String Arrays